### PR TITLE
Made all Curves only re-render when they have new points.

### DIFF
--- a/src/DrawTogether.UI/Client/Components/Curve.razor
+++ b/src/DrawTogether.UI/Client/Components/Curve.razor
@@ -15,7 +15,7 @@
 
     protected override bool ShouldRender()
     {
-        if (_points.Count() != Points.Count)
+        if (_points.Length != Points.Count)
         {
             _points = Points.ToArray();
             return true;
@@ -29,10 +29,10 @@
         double smoothness = 1.0 / 3.0;
 
         var result = "";
-        if (Points.Count() >= 2)
+        if (Points.Length >= 2)
         {
             result = $"M {Points[0].x} {Points[0].y} ";
-            for (int i = 1; i < Points.Count() - 1; i++)
+            for (int i = 1; i < Points.Length - 1; i++)
             {
                 result += $"S {Points[i - 1].x * smoothness / 2 + Points[i].x - Points[i + 1].x * smoothness / 2} {Points[i - 1].y * smoothness / 2 + Points[i].y - Points[i + 1].y * smoothness / 2} {Points[i].x} {Points[i].y} ";
             }

--- a/src/DrawTogether.UI/Client/Components/Curve.razor
+++ b/src/DrawTogether.UI/Client/Components/Curve.razor
@@ -1,7 +1,9 @@
 ﻿@using DrawTogether.UI.Shared
-<path d="@PathData(Points)" fill="None" stroke="@Stroke" stroke-width="@StrokeWidth"></path>
+<path d="@PathData(_points)" fill="None" stroke="@Stroke" stroke-width="@StrokeWidth"></path>
 
 @code {
+    private Point[] _points { get; set; } = new Point[0];
+
     [Parameter]
     public List<Point> Points { get; set; } = new List<Point>();
 
@@ -11,16 +13,26 @@
     [Parameter]
     public string Stroke { get; set; } = "#ff0000";
 
-    protected static string PathData(List<Point> Points)
+    protected override bool ShouldRender()
+    {
+        if (_points.Count() != Points.Count)
+        {
+            _points = Points.ToArray();
+            return true;
+        }
+        return false;
+    }
+
+    protected static string PathData(Point[] Points)
     {
     // Parameter for smoothness of path in interval [0, 0.5]
         double smoothness = 1.0 / 3.0;
 
         var result = "";
-        if (Points.Count >= 2)
+        if (Points.Count() >= 2)
         {
             result = $"M {Points[0].x} {Points[0].y} ";
-            for (int i = 1; i < Points.Count - 1; i++)
+            for (int i = 1; i < Points.Count() - 1; i++)
             {
                 result += $"S {Points[i - 1].x * smoothness / 2 + Points[i].x - Points[i + 1].x * smoothness / 2} {Points[i - 1].y * smoothness / 2 + Points[i].y - Points[i + 1].y * smoothness / 2} {Points[i].x} {Points[i].y} ";
             }


### PR DESCRIPTION
We talked about this on stream the other day. I had forgotten that we have `bool ShouldRender()` available for a component to override. So this small change simply makes it so that a Curve is only re-rendered if it has changed length.
This makes it so that there is a much smaller render overhead when you have added a lot of curves.