### PR TITLE
.NET Aspire: added support for data volumes

### DIFF
--- a/src/DrawTogether.AppHost/Configuration.cs
+++ b/src/DrawTogether.AppHost/Configuration.cs
@@ -1,0 +1,12 @@
+﻿namespace DrawTogether.AppHost;
+
+public class DrawTogetherConfiguration
+{
+    /// <summary>
+    /// Whether to use persistent volumes for our database.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to false so we don't accidentally persist data during testing.
+    /// </remarks>
+    public bool UseVolumes { get; set; } = false;
+}

--- a/src/DrawTogether.AppHost/Program.cs
+++ b/src/DrawTogether.AppHost/Program.cs
@@ -1,6 +1,17 @@
+using DrawTogether.AppHost;
+using Microsoft.Extensions.Configuration;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
+var drawTogetherAspireConfig = builder.Configuration.GetSection("DrawTogether")
+    .Get<DrawTogetherConfiguration>() ?? new DrawTogetherConfiguration();
+
 var sqlServer = builder.AddSqlServer("sql");
+if (drawTogetherAspireConfig.UseVolumes)
+{
+    // add a persistent data volume that can survive restarts
+    sqlServer.WithDataVolume();
+}
 
 var db = sqlServer.AddDatabase("DrawTogetherDb");
 

--- a/src/DrawTogether.AppHost/appsettings.json
+++ b/src/DrawTogether.AppHost/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "DrawTogether": {
+    "UseVolumes": true
   }
 }


### PR DESCRIPTION
This should allow data to be persisted locally or with a `docker compose` deployment, but not during testing.